### PR TITLE
Add forms support for modeless operations

### DIFF
--- a/lib/trailblazer/rails.rb
+++ b/lib/trailblazer/rails.rb
@@ -17,6 +17,13 @@ Trailblazer::Operation.contract_class.class_eval do
   end
 end
 
+class Reform::Form
+  # For modeless operations. It will be override if model is add.
+  def persisted?
+    model ? !(model.new_record? || model.destroyed?) : false
+  end
+end
+
 # Automatically set model_name on operation's contract when `Op::Model` is included.
 require "trailblazer/operation/model"
 require "trailblazer/operation/model/active_model"


### PR DESCRIPTION
Add forms support (`form_for` and `simple_form_for`) to make it works with this PR: https://github.com/trailblazer/trailblazer-rails/pull/5

When you use a modeless operation, the `persisted?` function must be override to make form helpers work. It makes form behave when implementing `Tyrant` for example.