### PR TITLE
Move injection of models before AddConceptFiles

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -4,7 +4,7 @@ require "trailblazer/loader"
 module Trailblazer
   class Railtie < ::Rails::Railtie
     def self.load_concepts(app)
-      Loader.new.(insert: [ModelFile, before: Loader::ConceptFiles]) { |file| require_dependency("#{app.root}/#{file}") }
+      Loader.new.(insert: [ModelFile, before: Loader::AddConceptFiles]) { |file| require_dependency("#{app.root}/#{file}") }
     end
 
     # This is to autoload Operation::Dispatch, etc. I'm simply assuming people find this helpful in Rails.


### PR DESCRIPTION
In the current version the models get injected before ConceptFiles causing them to take part in the sorting.
This results in something like this:
```ruby
["app/concepts/order/cell/create.rb",
 "app/concepts/order/cell/index.rb",
 "app/concepts/order/cell/part.rb",
 "app/concepts/order/cell/update.rb",
 "app/concepts/order/contract/create.rb",
 "app/concepts/order/contract/update.rb",
 "app/concepts/order/cell.rb",
 "app/concepts/order/policy.rb",
 "app/models/order.rb",
 "app/concepts/order/operation/create.rb",
 "app/concepts/order/operation/from_traject.rb",
 "app/concepts/order/operation/index.rb",
 "app/concepts/order/operation/search.rb",
 "app/concepts/order/operation/update.rb"]
```

But after moving the injection point:
```ruby
["app/models/order.rb",
 "app/concepts/order/cell.rb",
 "app/concepts/order/cell/create.rb",
 "app/concepts/order/cell/index.rb",
 "app/concepts/order/cell/part.rb",
 "app/concepts/order/cell/update.rb",
 "app/concepts/order/contract/create.rb",
 "app/concepts/order/contract/update.rb",
 "app/concepts/order/policy.rb",
 "app/concepts/order/operation/create.rb",
 "app/concepts/order/operation/from_traject.rb",
 "app/concepts/order/operation/index.rb",
 "app/concepts/order/operation/search.rb",
 "app/concepts/order/operation/update.rb"]
```

Seems logical to me that the model should be required before everything else.
The trailblazer-loader gem could do this sorting for us, but as we would like to keep it framework agnostic.