### PR TITLE
Use AS#on_load to verify that ActionController is properly loaded.

### DIFF
--- a/lib/trailblazer/rails/application_controller.rb
+++ b/lib/trailblazer/rails/application_controller.rb
@@ -1,3 +1,0 @@
-ApplicationController.class_eval do
-  include Trailblazer::Operation::Controller
-end

--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -26,7 +26,9 @@ module Trailblazer
     # end
 
     initializer "trailblazer.application_controller" do
-      require "trailblazer/rails/application_controller"
+      ActiveSupport.on_load(:action_controller) do
+        include Trailblazer::Operation::Controller
+      end
     end
 
     # Prepend model file, before the concept files like operation.rb get loaded.


### PR DESCRIPTION
I'm not exactly sure what is going on here with reopening `ApplicationController` in railtie, but it seems to interfere with other gems that try to include something in the similar fashion. Using `AS#on_load` helps to fix that.

Here is the issue I run into https://github.com/twitter/secureheaders/issues/135