### PR TITLE
Add concept renderer

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -28,6 +28,12 @@ module Trailblazer
     initializer "trailblazer.application_controller" do
       ActiveSupport.on_load(:action_controller) do
         include Trailblazer::Operation::Controller
+        ActionController.add_renderer :concept do |cell, options|
+          model = options.delete(:model) || @model
+          layout = options.delete(:layout)
+          options.slice!(:template, :prefixes)
+          render text: concept(cell, model, options), layout: layout
+        end
       end
     end
 


### PR DESCRIPTION
I find I am using the Rails views less and less, and am using cells almost exclusively in my controllers.
This makes my actions look like:

```
def show
  present SomeModel::Update
  render text: concept('some_model/cell', @model), layout: true
end
```

This PR allows you to rewrite it to:

```
def show
  present SomeModel::Update
  render concept: 'some_model/cell'
end
```

By default it will use @model with your concept, if you need something else,
you can specify it as `model: @operation`
 Layout will be used default, you no longer need to add it explicitly.
