### PR TITLE
Update trailblazer-rails.gemspec

### DIFF
--- a/trailblazer-rails.gemspec
+++ b/trailblazer-rails.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "trailblazer", ">= 1.0.4"
   spec.add_dependency "trailblazer-loader", ">= 0.0.7"
+  spec.add_dependency "trailblazer-cells"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Trailblazer-cells ought to be part of the rails stack by default.