### PR TITLE
Removes rails 5 deprecation warning

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -16,8 +16,14 @@ module Trailblazer
     initializer 'trailblazer.install', after: :load_config_initializers do |app|
       # the trb autoloading has to be run after initializers have been loaded, so we can tweak inclusion of features in
       # initializers.
-      ActionDispatch::Reloader.to_prepare do
-        Trailblazer::Railtie.load_concepts(app)
+      if ::Rails.version > '5.0'
+        ActiveSupport::Reloader.to_prepare do
+          Trailblazer::Railtie.load_concepts(app)
+        end
+      else
+        ActionDispatch::Reloader.to_prepare do
+          Trailblazer::Railtie.load_concepts(app)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #17 
Removes deprecated use of `ActionDispatch::Reloader` for rails versions 5 and above.
I used the version check against the `Rails.version` and not the `ActionPack::VERSION::STRING` since railties are created specifically for rails applications...
By the way, you gemspec states that the use of rails is optional, but you [require the railtie file](https://github.com/trailblazer/trailblazer-rails/blob/master/lib/trailblazer/rails.rb#L9) without a check for the existence of the `Rails` contstant. And the [railtie file](https://github.com/trailblazer/trailblazer-rails/blob/master/lib/trailblazer/rails/railtie.rb#L5) refers to the `Rails` constant. So, the gem would not works without rails anyway...