### PR TITLE
Blocking Method With Unamiable Results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 test/fake_app/log/*.log
+.idea/

--- a/lib/trailblazer/operation/responder.rb
+++ b/lib/trailblazer/operation/responder.rb
@@ -14,6 +14,7 @@ module Trailblazer::Operation::Responder
 
   def errors
     return [] if @valid
+    return contract.errors if self.respond_to?(:contract)
     [1]
   end
 


### PR DESCRIPTION
This is a small change, the method `Responder#errors`, when included in an `Operation`, becomes an obstacle that overrides the `Operation#errors` method which in the case of a recent JSON API I'm constructing, validation errors could not be provided in a response that reported 422 status code.  The detail in `Responder#errors` is obviously sparse, so in this case if self contains a method `:contract`, then relevant error messages may pass through.
