### PR TITLE
bugfix: support rails 3.X again 

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -43,7 +43,7 @@ module Trailblazer
       # Rails 5.0.0.rc1 says:
       # DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1
       # (use ActiveSupport::Reloader.to_prepare instead)
-      if ActiveSupport.version.release >= Gem::Version.new('5')
+      if Gem.loaded_specs['activesupport'].version >= Gem::Version.new('5')
         ActiveSupport::Reloader
       else
         ActionDispatch::Reloader


### PR DESCRIPTION
This got broken after commit https://github.com/trailblazer/trailblazer-rails/commit/34bdb24be79e73b08e143cbbc98e5b37718e153c

rails 3.X has  ActiveSupport::VERSION::MAX  (http://www.rubydoc.info/docs/rails/3.2.8/ActiveSupport/VERSION) 

instead of ActiveSupport.version.release in rails 4.X & 5.X (http://www.rubydoc.info/docs/rails/4.1.7/ActiveSupport#version-class_method)

So use generic gem mechanism to detect current version