### PR TITLE
Engine concept loading + better STI model support

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -33,9 +33,7 @@ module Trailblazer
       end
 
       # Load the app root (Dir is necessary to guarantee context for tests)
-      Dir.chdir(app.root) do
-        load_root(app.root)
-      end
+      load_root(app.root)
     end
 
     # This is to autoload Operation::Dispatch, etc. I'm simply assuming people find this helpful in Rails.


### PR DESCRIPTION
- Allow concepts to be loaded from engines
- Re-sort load order so that all models are first (better support for STI models).  Note this is a 99% solution, for outliers you may still need to be explicit and use `require_dependency`

This closes #13, #14, #30.

cc: @apotonick 