### PR TITLE
engine: find namespaced models in any subdirectory of `app/models`

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -48,7 +48,7 @@ module Trailblazer
 
     # Load all model files before any TRB files.
     AllModelFiles = ->(input, options) do
-      Dir.glob("#{options[:root]}/app/models/*.rb") + input
+      Dir.glob("#{options[:root]}/app/models/**/*.rb") + input
     end
 
     private


### PR DESCRIPTION
I have a few other issues with my branch of reform so I cannot say with 100% certainty, but I think this small glob change has everything I need for engines to be working.  In any case, I think this change is needed for anyone using namespaces.