### PR TITLE
Teach the Railtie to detect engines in Rails 3

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -14,15 +14,10 @@ module Trailblazer
     end
 
     def self.engines
-      if !defined?(::Rails::Engine)
-        # Rails <3.1
-        []
-      elsif ::Rails.application.railties.respond_to?(:engines)
-        # Rails 3.1+
-        ::Rails.application.railties.engines
-      else
-        # Rails 4+
+      if Gem::Version.new(::Rails.version) >= Gem::Version.new("4.1")
         ::Rails.application.railties.find_all { |tie| tie.is_a?(::Rails::Engine) }
+      else
+        ::Rails.application.railties.engines
       end
     end
 

--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -10,8 +10,19 @@ module Trailblazer
       # Loader.new.(insert: [ModelFile, before: Loader::AddConceptFiles]) { |file| require_dependency("#{app.root}/#{file}") }
       load_for(app)
 
-      ::Rails.application.railties.find_all { |tie| tie.is_a?(::Rails::Engine) }.each do |engine|
-        load_for(engine)
+      engines.each { |engine| load_for(engine) }
+    end
+
+    def self.engines
+      if !defined?(::Rails::Engine)
+        # Rails <3.1
+        []
+      elsif ::Rails.application.railties.respond_to?(:engines)
+        # Rails 3.1+
+        ::Rails.application.railties.engines
+      else
+        # Rails 4+
+        ::Rails.application.railties.find_all { |tie| tie.is_a?(::Rails::Engine) }
       end
     end
 


### PR DESCRIPTION
In Rails 3.1 the Railties class has an `#engines` method that does what
we want. Regrettably, in Rails 4 onwards this seems to be removed and
instead `Rails.application.railties` includes `Enumerable` instead.

Relates to #40 and #39. I'm not including this directly in #40 because there are some MiniTest-related issues preventing Rails 3 tests from running that I don't yet fully understand and wanted to get this in front of @apotonick's eyes.