### PR TITLE
Fix for https://github.com/trailblazer/trailblazer-rails/issues/50

### DIFF
--- a/lib/trailblazer/rails/controller.rb
+++ b/lib/trailblazer/rails/controller.rb
@@ -2,7 +2,7 @@ module Trailblazer::Rails
   module Controller
     def run(operation, params=self.params, *dependencies)
       result = operation.(
-        _run_params(params),
+        _run_params(params: params),
         *_run_runtime_options(*dependencies)
       )
 


### PR DESCRIPTION
trailblazer-rails/lib/trailblazer/rails/controller.rb @ line 5

Currently is:
_run_params(params),

Results in:
> unable to convert unpermitted parameters to hash #50

Fix:
_run_params(params: params),