### PR TITLE
Fix for https://github.com/trailblazer/trailblazer-rails/issues/51

### DIFF
--- a/lib/trailblazer/rails/controller.rb
+++ b/lib/trailblazer/rails/controller.rb
@@ -6,7 +6,7 @@ module Trailblazer::Rails
         *_run_runtime_options(*dependencies)
       )
 
-      model_name, contract_name = Gem::Version.new(::Trailblazer.version) >= Gem::Version.new("2.1") ? [:model, "contract.default"] : ["model", "contract.default"]
+      model_name, contract_name = Gem.loaded_specs['trailblazer'].version > Gem::Version.new("2.0.9") ? [:model, "contract.default"] : ["model", "contract.default"]
 
       @form  = Trailblazer::Rails::Form.new( result[ contract_name ], result[ model_name ].class )
       @model = result[ model_name ]


### PR DESCRIPTION
trailblazer-rails/lib/trailblazer/rails/controller.rb @ line 9

Currently is:
model_name, contract_name = Gem::Version.new(::Trailblazer.version) >= Gem::Version.new("2.1") ? [:model, "contract.default"] : ["model", "contract.default"]

Results in:
> undefined method `version' for Trailblazer:Module #51

Fix:
model_name, contract_name = Gem.loaded_specs['trailblazer'].version > Gem::Version.new("2.0.9") ? [:model, "contract.default"] : ["model", "contract.default"]