### PR TITLE
Divide Trailblazer::Railtie in 2 modules: code to load and code to include

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -1,5 +1,7 @@
 require "rails/railtie"
 require "trailblazer/loader"
+require "trailblazer/rails/railtie/extend_application_controller"
+require "trailblazer/rails/railtie/loader"
 
 module Trailblazer
   class Railtie < ::Rails::Railtie
@@ -9,58 +11,8 @@ module Trailblazer
     config.trailblazer.use_loader ||= true
     config.trailblazer.enable_tracing ||= false
 
-    def self.load_concepts(app)
-      # Loader.new.(insert: [ModelFile, before: Loader::AddConceptFiles]) { |file| require_dependency("#{app.root}/#{file}") }
-      load_for(app)
-
-      engines.each { |engine| load_for(engine) }
-    end
-
-    def self.engines
-      if Gem::Version.new(::Rails.version) >= Gem::Version.new("4.1")
-        ::Rails.application.railties.find_all { |tie| tie.is_a?(::Rails::Engine) }
-      else
-        ::Rails.application.railties.engines
-      end
-    end
-
-    def self.load_for(app)
-      Loader.new.(prepend: AllModelFiles, root: app.root) { |file| require_dependency(file) }
-    end
-
-    # This is to autoload Operation::Dispatch, etc. I'm simply assuming people find this helpful in Rails.
-    initializer "trailblazer.library_autoloading" do
-    end
-
-    # thank you, http://stackoverflow.com/a/17573888/465070
-    initializer 'trailblazer.install', after: "reform.form_extensions" do |app|
-      # the trb autoloading has to be run after initializers have been loaded, so we can tweak inclusion of features in
-      # initializers.
-      if config.trailblazer.use_loader
-        reloader_class.to_prepare do
-          Trailblazer::Railtie.load_concepts(app)
-        end
-      end
-    end
-
-    initializer "trailblazer.application_controller", before: "finisher_hook" do
-      reloader_class.to_prepare do
-        ActiveSupport.on_load(:action_controller) do |app|
-          Trailblazer::Railtie.extend_application_controller!(app)
-        end
-      end
-    end
-
-    # Prepend model file, before the concept files like operation.rb get loaded.
-    ModelFile = ->(input, options) do
-      model = "app/models/#{options[:name]}.rb"
-      File.exist?(model) ? [model] + input : input
-    end
-
-    # Load all model files before any TRB files.
-    AllModelFiles = ->(input, options) do
-      Dir.glob("#{options[:root]}/app/models/**/*.rb").sort + input
-    end
+    include Loader
+    include ExtendApplicationController
 
     private
 
@@ -74,18 +26,5 @@ module Trailblazer
         ActionDispatch::Reloader
       end
     end
-
-    module ExtendApplicationController
-      def extend_application_controller!(app)
-        controllers = Array(::Rails.application.config.trailblazer.application_controller).map { |x| x.to_s }
-        if controllers.include? app.to_s
-          app.send :include, Trailblazer::Rails::Controller
-          app.send :include, Trailblazer::Rails::Controller::Cell if defined?(::Cell)
-        end
-        app
-      end
-    end
-
-    extend ExtendApplicationController
   end
 end

--- a/lib/trailblazer/rails/railtie/extend_application_controller.rb
+++ b/lib/trailblazer/rails/railtie/extend_application_controller.rb
@@ -1,0 +1,28 @@
+require 'active_support/concern'
+
+module Trailblazer
+  class Railtie < ::Rails::Railtie
+    module ExtendApplicationController
+      extend ActiveSupport::Concern
+
+      included do
+        initializer "trailblazer.application_controller", before: "finisher_hook" do
+          reloader_class.to_prepare do
+            ActiveSupport.on_load(:action_controller) do |app|
+              Trailblazer::Railtie.extend_application_controller!(app)
+            end
+          end
+        end
+
+        def extend_application_controller!(app)
+          controllers = Array(::Rails.application.config.trailblazer.application_controller).map { |x| x.to_s }
+          if controllers.include? app.to_s
+            app.send :include, Trailblazer::Rails::Controller
+            app.send :include, Trailblazer::Rails::Controller::Cell if defined?(::Cell)
+          end
+          app
+        end
+      end
+    end
+  end
+end

--- a/lib/trailblazer/rails/railtie/loader.rb
+++ b/lib/trailblazer/rails/railtie/loader.rb
@@ -1,0 +1,56 @@
+require 'active_support/concern'
+
+module Trailblazer
+  class Railtie < ::Rails::Railtie
+    module Loader
+      extend ActiveSupport::Concern
+
+      included do
+        def self.load_concepts(app)
+        # Loader.new.(insert: [ModelFile, before: Loader::AddConceptFiles]) { |file| require_dependency("#{app.root}/#{file}") }
+          load_for(app)
+
+          engines.each { |engine| load_for(engine) }
+        end
+
+        def self.engines
+          if Gem::Version.new(::Rails.version) >= Gem::Version.new("4.1")
+            ::Rails.application.railties.find_all { |tie| tie.is_a?(::Rails::Engine) }
+          else
+            ::Rails.application.railties.engines
+          end
+        end
+
+        def self.load_for(app)
+          Trailblazer::Loader.new.(prepend: AllModelFiles, root: app.root) { |file| require_dependency(file) }
+        end
+
+        # Prepend model file, before the concept files like operation.rb get loaded.
+        ModelFile = ->(input, options) do
+          model = "app/models/#{options[:name]}.rb"
+          File.exist?(model) ? [model] + input : input
+        end
+
+        # Load all model files before any TRB files.
+        AllModelFiles = ->(input, options) do
+          Dir.glob("#{options[:root]}/app/models/**/*.rb").sort + input
+        end
+
+        # This is to autoload Operation::Dispatch, etc. I'm simply assuming people find this helpful in Rails.
+        initializer "trailblazer.library_autoloading" do
+        end
+
+        # thank you, http://stackoverflow.com/a/17573888/465070
+        initializer 'trailblazer.install', after: "reform.form_extensions" do |app|
+          # the trb autoloading has to be run after initializers have been loaded, so we can tweak inclusion of features in
+          # initializers.
+          if config.trailblazer.use_loader
+            reloader_class.to_prepare do
+              Trailblazer::Railtie.load_concepts(app)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this way in the future gem we are able to include only the "include" module so we don't load stuff twice

If this makes sense I'll send a PR for V1