### PR TITLE
Remove Reform dependency

### DIFF
--- a/lib/trailblazer/rails.rb
+++ b/lib/trailblazer/rails.rb
@@ -5,8 +5,6 @@ module Trailblazer
   end
 end
 
-require "reform/rails"
-
 require "trailblazer/rails/controller"
 require "trailblazer/rails/cell"
 require "trailblazer/rails/form"

--- a/trailblazer-rails.gemspec
+++ b/trailblazer-rails.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "trailblazer", ">= 2.1.0.beta1", "< 2.2.0"
   spec.add_dependency "trailblazer-loader", ">= 0.1.0"
-  spec.add_dependency "reform-rails", ">= 0.1.4", "< 0.2.0"
   spec.add_dependency "activesupport", ">= 5.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
Since in 2.1, we completely made Reform "just another optional feature", we could remove the reform-rails dependency.