### PR TITLE
Run rubocop in travis only for ruby 2.5

### DIFF
--- a/.rubocop-https---raw-githubusercontent-com-trailblazer-meta-master-rubocop-yml
+++ b/.rubocop-https---raw-githubusercontent-com-trailblazer-meta-master-rubocop-yml
@@ -100,7 +100,6 @@ Metrics/AbcSize:
   Max: 25
 Style/LambdaCall:
   Enabled: false
-# This to fix lots of failure in trailblazer-operation tests
 Style/Semicolon:
   Enabled: false
 Naming/UncommunicativeMethodParamName:
@@ -112,3 +111,5 @@ Layout/LeadingCommentSpace:
     - 'test/docs/**/*'
 Layout/AlignHash:
   EnforcedHashRocketStyle: table
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,27 +1,10 @@
 inherit_from:
   - https://raw.githubusercontent.com/trailblazer/meta/master/rubocop.yml
 
-Style/ClassCheck:
-  Exclude:
-    - 'lib/trailblazer/rails/cell.rb'
-
-Metrics/AbcSize:
-  Exclude:
-    - 'lib/trailblazer/rails/controller.rb'
-
 Bundler/DuplicatedGem:
   Enabled: false
 
 Style/Send:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/ClassAndModuleChildren:
   Enabled: false
 
 # required when rubocop is run via travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
     gemfile: test/rails5.1/Gemfile
 
   - rvm: 2.5.1
-    env: TEST_SUITE=rails5.2
     gemfile: test/rails5.2/Gemfile
+    script: cd test/rails5.2 && bundle install && bundle exec rake test && cd ../.. && bundle install && bundle exec rake rubocop
 
-script: cd test/$TEST_SUITE && bundle install && bundle exec rake test && cd ../.. && bundle install && bundle exec rake rubocop
+script: cd test/$TEST_SUITE && bundle install && bundle exec rake test
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,25 +1,25 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in trailblazer-rails.gemspec
 gemspec
 
-case ENV['GEMS_SOURCE']
-  when 'local'
+case ENV["GEMS_SOURCE"]
+  when "local"
     gem "cells-erb", path: "../cells-erb"
     gem "cells-rails", path: "../cells-rails"
     gem "reform-rails", path: "../reform-rails"
     gem "trailblazer", path: "../trailblazer"
     gem "trailblazer-cells", path: "../trailblazer-cells"
     gem "trailblazer-loader", path: "../trailblazer-loader"
-  when 'github'
+  when "github"
     gem "cells-erb", github: "trailblazer/cells-erb"
     gem "cells-rails", github: "trailblazer/cells-rails"
     gem "reform-rails", github: "trailblazer/reform-rails"
     gem "trailblazer", github: "trailblazer/trailblazer"
     gem "trailblazer-cells", github: "trailblazer/trailblazer-cells"
     gem "trailblazer-loader", github: "trailblazer/trailblazer-loader"
-  when 'custom'
-    eval_gemfile('GemfileCustom')
+  when "custom"
+    eval_gemfile("GemfileCustom")
   else # use rubygems releases
     gem "cells-erb"
     gem "cells-rails"

--- a/Rakefile
+++ b/Rakefile
@@ -5,12 +5,12 @@ require "rubocop/rake_task"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
 RuboCop::RakeTask.new(:rubocop)
 
-desc 'Remove temporary files'
+desc "Remove temporary files"
 task :clean do
   `rm -rf *.gem doc pkg coverage test-reports`
   %x(rm -f `find . -name '*.rbc'`)
@@ -21,5 +21,5 @@ task :gem do
   `gem build trailblazer-rails.gemspec`
 end
 
-desc 'Running Tests'
+desc "Running Tests"
 task default: %i[clean test]

--- a/lib/trailblazer-rails.rb
+++ b/lib/trailblazer-rails.rb
@@ -1,1 +1,1 @@
-require "trailblazer/rails"
+require "trailblazer/rails" # rubocop:disable Naming/FileName

--- a/lib/trailblazer/rails/cell.rb
+++ b/lib/trailblazer/rails/cell.rb
@@ -3,7 +3,7 @@ module Trailblazer::Rails::Controller::Cell
 
   module Render
     def render(cell = nil, options = {}, *, &block)
-      return super unless cell.kind_of?(::Cell::ViewModel)
+      return super unless cell.kind_of?(::Cell::ViewModel) # rubocop:disable Style/ClassCheck
 
       render_cell(cell, options)
     end

--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -7,7 +7,7 @@ module Trailblazer
   class Railtie < ::Rails::Railtie
     config.trailblazer = ActiveSupport::OrderedOptions.new
     ## Accept also an Array of controllers
-    config.trailblazer.application_controller ||= 'ActionController::Base'
+    config.trailblazer.application_controller ||= "ActionController::Base"
     config.trailblazer.enable_loader ||= true
     config.trailblazer.enable_tracing ||= false
 
@@ -20,7 +20,7 @@ module Trailblazer
       # Rails 5.0.0.rc1 says:
       # DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1
       # (use ActiveSupport::Reloader.to_prepare instead)
-      if Gem.loaded_specs['activesupport'].version >= Gem::Version.new('5')
+      if Gem.loaded_specs["activesupport"].version >= Gem::Version.new("5")
         ActiveSupport::Reloader
       else
         ActionDispatch::Reloader

--- a/test/rails4.2/Gemfile
+++ b/test/rails4.2/Gemfile
@@ -1,12 +1,12 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'actionpack', '~> 4.2.10'
-gem 'activerecord', '~> 4.2.10'
+gem "actionpack", "~> 4.2.10"
+gem "activerecord", "~> 4.2.10"
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem "sqlite3"
 # Use SCSS for stylesheets
 
-eval_gemfile('../../Gemfile')
+eval_gemfile("../../Gemfile")
 
 group :test do
   gem "minitest-rails-capybara"

--- a/test/rails4.2/Rakefile
+++ b/test/rails4.2/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks

--- a/test/rails4.2/bin/bundle
+++ b/test/rails4.2/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/test/rails4.2/bin/rails
+++ b/test/rails4.2/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/test/rails4.2/bin/rake
+++ b/test/rails4.2/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/test/rails4.2/bin/setup
+++ b/test/rails4.2/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'pathname'
+require "pathname"
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.

--- a/test/rails4.2/config.ru
+++ b/test/rails4.2/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application

--- a/test/rails4.2/config/application.rb
+++ b/test/rails4.2/config/application.rb
@@ -1,6 +1,6 @@
-require File.expand_path('boot', __dir__)
+require File.expand_path("boot", __dir__)
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/test/rails4.2/config/boot.rb
+++ b/test/rails4.2/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/test/rails4.2/config/environment.rb
+++ b/test/rails4.2/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('application', __dir__)
+require File.expand_path("application", __dir__)
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/test/rails4.2/config/environments/test.rb
+++ b/test/rails4.2/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/test/rails4.2/config/initializers/session_store.rb
+++ b/test/rails4.2/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_rails4_2_session'
+Rails.application.config.session_store :cookie_store, key: "_rails4_2_session"

--- a/test/rails4.2/test/integration/args_controller_test.rb
+++ b/test/rails4.2/test/integration/args_controller_test.rb
@@ -3,6 +3,6 @@ require "test_helper"
 class ArgsControllerTest < Trailblazer::Test::Integration
   it "run Song::Create, params, current_user: Module" do
     visit "/args/with_args"
-    page.body.must_match '>{:fake=&gt;&quot;bla&quot;} Module<'
+    page.body.must_match ">{:fake=&gt;&quot;bla&quot;} Module<"
   end
 end

--- a/test/rails4.2/test/integration/params_controller_test.rb
+++ b/test/rails4.2/test/integration/params_controller_test.rb
@@ -3,6 +3,6 @@ require "test_helper"
 class ArtistsControllerTest < Trailblazer::Test::Integration
   it "run Song::Create, params, current_user: Module" do
     visit "/params/with_args"
-    page.body.must_match '{&quot;controller&quot;=&gt;&quot;params&quot;, &quot;action&quot;=&gt;&quot;with_args&quot;} Module'
+    page.body.must_match "{&quot;controller&quot;=&gt;&quot;params&quot;, &quot;action&quot;=&gt;&quot;with_args&quot;} Module"
   end
 end

--- a/test/rails4.2/test/test_helper.rb
+++ b/test/rails4.2/test/test_helper.rb
@@ -1,6 +1,6 @@
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
-require 'rails/test_help'
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
+require "rails/test_help"
 
 require "trailblazer/rails/test/integration"
 

--- a/test/rails5.0/Gemfile
+++ b/test/rails5.0/Gemfile
@@ -1,12 +1,12 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'actionpack', '~> 5.0.7'
-gem 'activerecord', '~> 5.0.7'
+gem "actionpack", "~> 5.0.7"
+gem "activerecord", "~> 5.0.7"
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem "sqlite3"
 
-eval_gemfile('../../Gemfile')
+eval_gemfile("../../Gemfile")
 
 group :test do
   gem "minitest-rails-capybara"

--- a/test/rails5.0/Rakefile
+++ b/test/rails5.0/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks

--- a/test/rails5.0/bin/bundle
+++ b/test/rails5.0/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/test/rails5.0/bin/rails
+++ b/test/rails5.0/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/test/rails5.0/bin/rake
+++ b/test/rails5.0/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/test/rails5.0/bin/setup
+++ b/test/rails5.0/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'pathname'
+require "pathname"
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.

--- a/test/rails5.0/config.ru
+++ b/test/rails5.0/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application

--- a/test/rails5.0/config/application.rb
+++ b/test/rails5.0/config/application.rb
@@ -1,6 +1,6 @@
-require File.expand_path('boot', __dir__)
+require File.expand_path("boot", __dir__)
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/test/rails5.0/config/boot.rb
+++ b/test/rails5.0/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/test/rails5.0/config/environment.rb
+++ b/test/rails5.0/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('application', __dir__)
+require File.expand_path("application", __dir__)
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/test/rails5.0/config/environments/test.rb
+++ b/test/rails5.0/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Configure static file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.public_file_server.headers = {'Cache-Control' => 'public, max-age=3600'}
+  config.public_file_server.headers = {"Cache-Control" => "public, max-age=3600"}
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/test/rails5.0/config/initializers/session_store.rb
+++ b/test/rails5.0/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_rails_session'
+Rails.application.config.session_store :cookie_store, key: "_rails_session"

--- a/test/rails5.0/test/integration/args_controller_test.rb
+++ b/test/rails5.0/test/integration/args_controller_test.rb
@@ -3,6 +3,6 @@ require "test_helper"
 class ArgsControllerTest < Trailblazer::Test::Integration
   it "run Song::Create,current_user: Module" do
     visit "/args/with_args"
-    page.body.must_match '>{:fake=&gt;&quot;bla&quot;} Module<'
+    page.body.must_match ">{:fake=&gt;&quot;bla&quot;} Module<"
   end
 end

--- a/test/rails5.0/test/integration/params_controller_test.rb
+++ b/test/rails5.0/test/integration/params_controller_test.rb
@@ -3,6 +3,6 @@ require "test_helper"
 class ArtistsControllerTest < Trailblazer::Test::Integration
   it "run Song::Create, params, current_user: Module" do
     visit "/params/with_args"
-    page.body.must_match '{&quot;controller&quot;=&gt;&quot;params&quot;, &quot;action&quot;=&gt;&quot;with_args&quot;} Module'
+    page.body.must_match "{&quot;controller&quot;=&gt;&quot;params&quot;, &quot;action&quot;=&gt;&quot;with_args&quot;} Module"
   end
 end

--- a/test/rails5.0/test/test_helper.rb
+++ b/test/rails5.0/test/test_helper.rb
@@ -1,6 +1,6 @@
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
-require 'rails/test_help'
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
+require "rails/test_help"
 
 require "trailblazer/rails/test/integration"
 

--- a/test/rails5.1/Gemfile
+++ b/test/rails5.1/Gemfile
@@ -1,12 +1,12 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'actionpack', '~> 5.1.4'
-gem 'activerecord', '~> 5.1.4'
+gem "actionpack", "~> 5.1.4"
+gem "activerecord", "~> 5.1.4"
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem "sqlite3"
 
-eval_gemfile('../../Gemfile')
+eval_gemfile("../../Gemfile")
 
 group :test do
   gem "minitest-rails-capybara"

--- a/test/rails5.1/Rakefile
+++ b/test/rails5.1/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks

--- a/test/rails5.1/bin/bundle
+++ b/test/rails5.1/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/test/rails5.1/bin/rails
+++ b/test/rails5.1/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/test/rails5.1/bin/rake
+++ b/test/rails5.1/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/test/rails5.1/bin/setup
+++ b/test/rails5.1/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'pathname'
+require "pathname"
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.

--- a/test/rails5.1/config.ru
+++ b/test/rails5.1/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application

--- a/test/rails5.1/config/application.rb
+++ b/test/rails5.1/config/application.rb
@@ -1,6 +1,6 @@
-require File.expand_path('boot', __dir__)
+require File.expand_path("boot", __dir__)
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/test/rails5.1/config/boot.rb
+++ b/test/rails5.1/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/test/rails5.1/config/environment.rb
+++ b/test/rails5.1/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('application', __dir__)
+require File.expand_path("application", __dir__)
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/test/rails5.1/config/environments/test.rb
+++ b/test/rails5.1/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Configure static file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.public_file_server.headers = {'Cache-Control' => 'public, max-age=3600'}
+  config.public_file_server.headers = {"Cache-Control" => "public, max-age=3600"}
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/test/rails5.1/config/initializers/session_store.rb
+++ b/test/rails5.1/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_rails_session'
+Rails.application.config.session_store :cookie_store, key: "_rails_session"

--- a/test/rails5.1/test/integration/args_controller_test.rb
+++ b/test/rails5.1/test/integration/args_controller_test.rb
@@ -3,6 +3,6 @@ require "test_helper"
 class ArgsControllerTest < Trailblazer::Test::Integration
   it "run Song::Create,current_user: Module" do
     visit "/args/with_args"
-    page.body.must_match '>{:fake=&gt;&quot;bla&quot;} Module<'
+    page.body.must_match ">{:fake=&gt;&quot;bla&quot;} Module<"
   end
 end

--- a/test/rails5.1/test/integration/params_controller_test.rb
+++ b/test/rails5.1/test/integration/params_controller_test.rb
@@ -3,6 +3,6 @@ require "test_helper"
 class ArtistsControllerTest < Trailblazer::Test::Integration
   it "run Song::Create, params, current_user: Module" do
     visit "/params/with_args"
-    page.body.must_match '{&quot;controller&quot;=&gt;&quot;params&quot;, &quot;action&quot;=&gt;&quot;with_args&quot;} Module'
+    page.body.must_match "{&quot;controller&quot;=&gt;&quot;params&quot;, &quot;action&quot;=&gt;&quot;with_args&quot;} Module"
   end
 end

--- a/test/rails5.1/test/test_helper.rb
+++ b/test/rails5.1/test/test_helper.rb
@@ -1,6 +1,6 @@
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
-require 'rails/test_help'
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
+require "rails/test_help"
 
 require "trailblazer/rails/test/integration"
 

--- a/test/rails5.2/Gemfile
+++ b/test/rails5.2/Gemfile
@@ -1,12 +1,12 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'actionpack', '~> 5.2.0'
-gem 'activerecord', '~> 5.2.0'
+gem "actionpack", "~> 5.2.0"
+gem "activerecord", "~> 5.2.0"
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem "sqlite3"
 
-eval_gemfile('../../Gemfile')
+eval_gemfile("../../Gemfile")
 
 group :test do
   gem "minitest-capybara"

--- a/test/rails5.2/Rakefile
+++ b/test/rails5.2/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks

--- a/test/rails5.2/app/controllers/args_controller.rb
+++ b/test/rails5.2/app/controllers/args_controller.rb
@@ -11,10 +11,10 @@ class ArgsController < ApplicationController
 
   def _assign_trb_ivars(_result)
     super
-    @model = 'my_model'
+    @model = "my_model"
   end
 
   def _wrap_with_trb_form(_form, _model)
-    'my_form'
+    "my_form"
   end
 end

--- a/test/rails5.2/bin/bundle
+++ b/test/rails5.2/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/test/rails5.2/bin/rails
+++ b/test/rails5.2/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/test/rails5.2/bin/rake
+++ b/test/rails5.2/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/test/rails5.2/bin/setup
+++ b/test/rails5.2/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require 'pathname'
+require "pathname"
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new File.expand_path("..", __dir__)
 
 Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.

--- a/test/rails5.2/config.ru
+++ b/test/rails5.2/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application

--- a/test/rails5.2/config/application.rb
+++ b/test/rails5.2/config/application.rb
@@ -1,6 +1,6 @@
-require File.expand_path('boot', __dir__)
+require File.expand_path("boot", __dir__)
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/test/rails5.2/config/boot.rb
+++ b/test/rails5.2/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/test/rails5.2/config/environment.rb
+++ b/test/rails5.2/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('application', __dir__)
+require File.expand_path("application", __dir__)
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/test/rails5.2/config/environments/test.rb
+++ b/test/rails5.2/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Configure static file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.public_file_server.headers = {'Cache-Control' => 'public, max-age=3600'}
+  config.public_file_server.headers = {"Cache-Control" => "public, max-age=3600"}
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/test/rails5.2/config/initializers/session_store.rb
+++ b/test/rails5.2/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_rails_session'
+Rails.application.config.session_store :cookie_store, key: "_rails_session"

--- a/test/rails5.2/test/integration/args_controller_test.rb
+++ b/test/rails5.2/test/integration/args_controller_test.rb
@@ -4,8 +4,8 @@ class ArgsControllerTest < Minitest::Capybara::Spec
   it "run Song::Create,current_user: Module" do
     visit "/args/with_args"
 
-    page.body.must_match '>{:fake=&gt;&quot;bla&quot;} Module<'
-    page.body.must_match '>my_model<'
-    page.body.must_match '>my_form<'
+    page.body.must_match ">{:fake=&gt;&quot;bla&quot;} Module<"
+    page.body.must_match ">my_model<"
+    page.body.must_match ">my_form<"
   end
 end

--- a/test/rails5.2/test/integration/params_controller_test.rb
+++ b/test/rails5.2/test/integration/params_controller_test.rb
@@ -3,6 +3,6 @@ require "test_helper"
 class ParamsControllerTest < Minitest::Capybara::Spec
   it "run Song::Create, params, current_user: Module" do
     visit "/params/with_args"
-    page.body.must_match '{&quot;controller&quot;=&gt;&quot;params&quot;, &quot;action&quot;=&gt;&quot;with_args&quot;} Module'
+    page.body.must_match "{&quot;controller&quot;=&gt;&quot;params&quot;, &quot;action&quot;=&gt;&quot;with_args&quot;} Module"
   end
 end

--- a/test/rails5.2/test/test_helper.rb
+++ b/test/rails5.2/test/test_helper.rb
@@ -1,6 +1,6 @@
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
-require 'rails/test_help'
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
+require "rails/test_help"
 
 # require "trailblazer/rails/test/integration"
 require "minitest/autorun"

--- a/trailblazer-rails.gemspec
+++ b/trailblazer-rails.gemspec
@@ -1,6 +1,6 @@
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'trailblazer/rails/version'
+require "trailblazer/rails/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "trailblazer-rails"


### PR DESCRIPTION
I don't see the point to run rubocop for each run of travis, let's run it only for the latest version