### PR TITLE
trailblazer-loader has been replaced by zeitwerk

### DIFF
--- a/lib/trailblazer/rails/railtie.rb
+++ b/lib/trailblazer/rails/railtie.rb
@@ -1,5 +1,4 @@
 require "rails/railtie"
-require "trailblazer/loader"
 require "trailblazer/rails/railtie/extend_application_controller"
 require "trailblazer/rails/railtie/loader"
 


### PR DESCRIPTION
`trailblazer-loader` was removed in previous commit :

```diff
diff --git a/trailblazer-rails.gemspec b/trailblazer-rails.gemspec
index 2747dea..cb29910 100644
--- a/trailblazer-rails.gemspec
+++ b/trailblazer-rails.gemspec
@@ -9,16 +9,16 @@ Gem::Specification.new do |spec|
   spec.email         = ["apotonick@gmail.com"]
 
   spec.summary       = "Convenient Rails support for Trailblazer."
-  spec.homepage      = "http://trailblazer.to/gems/trailblazer/2.0/rails.html"
+  spec.homepage      = "https://trailblazer.to/2.1/docs/trailblazer.html#trailblazer-rails"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test)/}) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "railties", ">= 5.2.0"
-  spec.add_dependency "trailblazer", ">= 2.1.0.rc11", "< 2.2.0"
-  spec.add_dependency "trailblazer-loader", ">= 0.1.0"
+  spec.add_dependency "trailblazer", ">= 2.1.0", "< 2.2.0"
 
+  spec.add_development_dependency "trailblazer-loader", ">= 0.1.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
```