### PR TITLE
Pass keyword arguments to the success result block

### DIFF
--- a/test/dummy/app/concepts/extractable_keywords/operation/extract.rb
+++ b/test/dummy/app/concepts/extractable_keywords/operation/extract.rb
@@ -1,0 +1,12 @@
+module ExtractableKeywords
+  module Operation
+    class Extract < Trailblazer::Operation
+      step :add_keywords
+      
+      def add_keywords(context, **)
+        context[:keyword_1] = 'That'
+        context[:keyword_2] = 'worked'
+      end
+    end
+  end
+end

--- a/test/dummy/app/controllers/extractable_keywords_controller.rb
+++ b/test/dummy/app/controllers/extractable_keywords_controller.rb
@@ -1,0 +1,13 @@
+class ExtractableKeywordsController < ApplicationController
+  def extract_one
+    run ExtractableKeywords::Operation::Extract do |_ctx, keyword_1:, **|
+      render plain: "#{keyword_1}"
+    end
+  end
+  
+  def extract_all
+    run ExtractableKeywords::Operation::Extract do |_ctx, keyword_1:, keyword_2:, **|
+      render plain: "#{keyword_1} #{keyword_2}"
+    end
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -16,4 +16,7 @@ Rails.application.routes.draw do
   get "cells/with_layout", controller: "cells/with_layout"
   get "cells/without_layout", controller: "cells/without_layout"
   get "cells/with_explicit_layout", controller: "cells/with_explicit_layout"
+
+  get "extractable_keywords/extract_one", controller: "extractable_keywords/extract_one"
+  get "extractable_keywords/extract_all", controller: "extractable_keywords/extract_all"
 end

--- a/test/integration/extractable_keywords_controller_test.rb
+++ b/test/integration/extractable_keywords_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class ExtractableKeywordsControllerTest < Minitest::Capybara::Spec
+  it "extract_one" do
+    visit "/extractable_keywords/extract_one"
+    assert_equal 'That', page.body
+  end
+
+  it "extract_all" do
+    visit "/extractable_keywords/extract_all"
+    assert_equal 'That worked', page.body
+  end
+end


### PR DESCRIPTION
I can't run the tests and I don't know if it's necessary.

But if it is, I would like to say that I tried to install the gems and run the rake test, but I received `test/dummy/config/application.rb:5:in 'require': cannot load such file -- active_record/railtie (LoadError)`.

I could create a contribution guide to this project, to make it easier for new contributors.

resolves #123